### PR TITLE
fix: do not ignore the bibtool return code when checking

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -196,8 +196,14 @@ runs:
         sudo apt-get update
         sudo apt-get install -y bibtool
 
-    - name: lint references.bib
-      if: ${{ inputs.lint-bib-file == 'true' && (inputs.mode == 'check' || inputs.mode == 'suggest' || steps.user_permission.outputs.require-result == 'true') }}
+    - name: lint references.bib (check)
+      if: ${{ inputs.lint-bib-file == 'true' && inputs.mode == 'check' }}
+      shell: bash
+      run: |
+        ./scripts/lint-bib.sh
+
+    - name: lint references.bib (suggest)
+      if: ${{ inputs.lint-bib-file == 'true' && (inputs.mode == 'suggest' || steps.user_permission.outputs.require-result == 'true') }}
       shell: bash
       run: |
         # ignoring the return code allows the following `reviewdog` step to add GitHub suggestions


### PR DESCRIPTION
We ignore the return code when applying reviewdog suggestions, since a failure in this step means the suggestions won't be applied. But when doing a non-interactive check we need to actually error out if there are problems.