### PR TITLE
feat(install-bibtool): use --no-install-recommends with apt-get

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -194,7 +194,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y bibtool
+        sudo apt-get install --no-install-recommends -y bibtool
 
     - name: lint references.bib (check)
       if: ${{ inputs.lint-bib-file == 'true' && inputs.mode == 'check' }}


### PR DESCRIPTION
According to `apt-cache show bibtool`, bibtool lists `texlive-base` as a suggestion, not a true dependency.

```
$ docker run leanprovercommunity/gitpod4 bash -c "apt-cache show bibtool | head -n13"
Package: bibtool
Architecture: amd64
Version: 2.68+ds-1
Priority: optional
Section: universe/tex
Origin: Ubuntu
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Original-Maintainer: Debian Tex Maintainers <debian-tex-maint@lists.debian.org>
Bugs: https://bugs.launchpad.net/ubuntu/+filebug
Installed-Size: 994
Depends: libc6 (>= 2.14), libkpathsea6 (>= 2020.20200327.54578), tex-common (>= 6.13)
Recommends: texlive-base
Enhances: texlive-base
```


This appears to be responsible for the majority of the ~118MB downloaded during CI.
E.g. on a fresh gitpod image:
```
$ docker run leanprovercommunity/gitpod4 bash -c "sudo apt-get install bibtool --assume-no" | grep 'Need to get'
Need to get 168 MB of archives.
$ docker run leanprovercommunity/gitpod4 bash -c "sudo apt-get install bibtool --no-install-recommends --assume-no" | grep 'Need to get'
Need to get 851 kB of archives.
```