### PR TITLE
Revert #5: --no-install-recommends breaks bibtool on Ubuntu noble

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -194,7 +194,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install --no-install-recommends -y bibtool
+        sudo apt-get install -y bibtool
 
     - name: lint references.bib (check)
       if: ${{ inputs.lint-bib-file == 'true' && inputs.mode == 'check' }}


### PR DESCRIPTION
This PR reverts #5 (feat(install-bibtool): use --no-install-recommends with apt-get).

The change is unsafe on Ubuntu noble runners. Dropping the `Recommends: texlive-base` pull-in leaves `libkpathsea6` without a working kpathsea configuration, so `bibtool` silently fails to find `docs/references.bib` and emits `*** BibTool WARNING: File docs/references.bib not found.`

The downstream effect in mathlib's `scripts/lint-bib.sh` is catastrophic: the script runs `bibtool -i docs/references.bib -o docs/references.bib`, which truncates the output file before reading the input. With the input lookup broken, bibtool produces an empty file, wiping all 6041 lines of the bibliography.

The failure surfaced on the bors staging build for the corresponding pin bump on mathlib4:

- https://github.com/leanprover-community/mathlib4/pull/39228 → `ci (staging) / Lint style` failed with `@@ -1,6041 +0,0 @@` in the `diff -U8` step (https://github.com/leanprover-community/mathlib4/actions/runs/25708544738/job/75483743766#step:2:540).
- The `Lint and suggest` job on the same PR hit the same destruction, but its script runs `./scripts/lint-bib.sh || true`, so the file-wipe was passed to reviewdog instead of failing the job.

Comparing apt output between the last passing and first failing staging runs:

| Run | apt install | New packages |
| --- | --- | --- |
| Passing (master, 2026-05-11 23:46) | `apt-get install -y bibtool` | `bibtool` + ~118 MB of texlive |
| Failing (this change, 2026-05-12 01:58) | `apt-get install --no-install-recommends -y bibtool` | `bibtool libkpathsea6` only |

`tex-common` is pulled in as a hard `Depends:` in both cases and its triggers ran, but on noble that is not sufficient to give `libkpathsea6` a usable `texmf.cnf`. So although Debian metadata marks `texlive-base` only as `Recommends:`, it is *de facto* required for bibtool's kpathsea-based file resolution on this image.

The downstream pin bumps prepared against the new SHA (https://github.com/leanprover-community/mathlib4/pull/39228, https://github.com/leanprover/cslib/pull/561, https://github.com/Verified-zkEVM/VCV-io/pull/386) are being closed unmerged.

A future change that gets the savings would need to install bibtool plus a minimal kpathsea-config-providing package (smaller than `texlive-base`), or set `TEXMFCNF`/`KPATHSEA_PATH` to give kpathsea a working config without the full texlive footprint. Either approach needs testing on noble before relanding.

🤖 Prepared with Claude Code